### PR TITLE
[php-result] LogicExceptionを使用するよう修正

### DIFF
--- a/src/Err.php
+++ b/src/Err.php
@@ -50,7 +50,7 @@ final readonly class Err extends Result
     #[Override]
     public function unwrap(): never
     {
-        throw new \RuntimeException('called Result::unwrap() on an Err value');
+        throw new \LogicException('called Result::unwrap() on an Err value');
     }
 
     /**

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -59,7 +59,7 @@ final readonly class Ok extends Result
     #[Override]
     public function unwrapErr(): never
     {
-        throw new \RuntimeException('called Result::unwrapErr() on an Ok value');
+        throw new \LogicException('called Result::unwrapErr() on an Ok value');
     }
 
     /**


### PR DESCRIPTION
## Summary
- `unwrap()` と `unwrapErr()` で投げる例外を `RuntimeException` から `LogicException` に変更

## Details
Result型の不適切な使用（Err値に対する`unwrap()`、Ok値に対する`unwrapErr()`）は実装のミス（プログラムのロジックエラー）であるため、PHPの慣習に従って`LogicException`を使用するよう修正しました。

### 変更内容
- `Ok::unwrapErr()`: RuntimeException → LogicException
- `Err::unwrap()`: RuntimeException → LogicException

これにより、実行時エラーではなくプログラミングエラーであることが明確になります。