### PR TITLE
feat: improve PHPStan type annotations for Result interface

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -16,6 +16,7 @@ interface Result
      * 結果が成功（Ok）の場合に true を返します.
      *
      * @phpstan-assert-if-true Ok<T> $this
+     * @phpstan-assert-if-false Err<E> $this
      *
      * @return bool
      */
@@ -34,6 +35,7 @@ interface Result
      * 結果が失敗（Err）の場合に true を返します.
      *
      * @phpstan-assert-if-true Err<E> $this
+     * @phpstan-assert-if-false Ok<T> $this
      *
      * @return bool
      */
@@ -51,14 +53,14 @@ interface Result
     /**
      * 成功値を返します。失敗の場合は例外を投げます.
      *
-     * @return T
+     * @return ($this is Ok<T> ? T : never)
      */
     public function unwrap(): mixed;
 
     /**
      * エラー値を返します。成功の場合は例外を投げます.
      *
-     * @return E
+     * @return ($this is Err<E> ? E : never)
      */
     public function unwrapErr(): mixed;
 
@@ -67,7 +69,7 @@ interface Result
      *
      * @template U
      * @param U $default
-     * @return T|U
+     * @return ($this is Ok<T> ? T : U)
      */
     public function unwrapOr(mixed $default): mixed;
 


### PR DESCRIPTION
## Summary
- Add `@phpstan-assert-if-false` annotations to `isOk()` and `isErr()` methods
- Use conditional return types for `unwrap()`, `unwrapErr()`, and `unwrapOr()` methods
- Improve type inference and reduce PHPStan false positives

## Changes
This PR enhances the PHPStan type annotations in the Result interface to provide better type safety:

### 1. Assertion Annotations
- `isOk()`: Now asserts that `$this` is `Err<E>` when false
- `isErr()`: Now asserts that `$this` is `Ok<T>` when false

### 2. Conditional Return Types
- `unwrap()`: `@return ($this is Ok<T> ? T : never)`
- `unwrapErr()`: `@return ($this is Err<E> ? E : never)`
- `unwrapOr()`: `@return ($this is Ok<T> ? T : U)`

## Benefits
- Better type inference in conditional blocks
- Reduced need for PHPStan ignore patterns
- More closely aligned with Rust's Result type safety
- Improved developer experience with more accurate type information

## Test Plan
- [x] PHPStan analysis passes without errors
- [x] All existing functionality remains unchanged
- [x] Type annotations are properly recognized by PHPStan