### PR TITLE
Add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PHP Result
 
 ![Packagist Version](https://img.shields.io/packagist/v/valbeat/result)
+[![codecov](https://codecov.io/gh/valbeat/php-result/branch/main/graph/badge.svg?token=B1P4MQMP7J)](https://codecov.io/gh/valbeat/php-result)
 
 A Result type implementation for PHP inspired by Rust's `Result<T, E>` type.
 


### PR DESCRIPTION
## Summary
Add Codecov badge to README to display code coverage status.

## Changes
- Added Codecov badge below the Packagist version badge
- Badge links to the Codecov dashboard for this repository

## Benefits
- 📊 **Visibility**: Shows current test coverage percentage at a glance
- 🔗 **Quick access**: Direct link to detailed coverage reports
- 📈 **Transparency**: Demonstrates code quality commitment to users

## Preview
\![Codecov Badge](https://codecov.io/gh/valbeat/php-result/branch/main/graph/badge.svg?token=B1P4MQMP7J)

The badge will display the current coverage percentage and update automatically with each push to main.