### PR TITLE
feat: sealed interface, covariant templates, and error-type composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,24 @@ Each step in a chain may fail with a **different error type**. The error types
 are composed into a union, so PHPStan tracks every error the chain can produce:
 
 ```php
-/** @return Result<UserId, ValidationError> */
-function validateUserId(string $raw): Result { /* ... */ }
+final class ValidationError {}
+final class NotFoundError {}
 
-/** @return Result<User, NotFoundError> */
-function findUserById(UserId $id): Result { /* ... */ }
+/** @return Result<int, ValidationError> */
+function validateUserId(string $raw): Result
+{
+    return ctype_digit($raw) ? new Ok((int) $raw) : new Err(new ValidationError());
+}
 
-// PHPStan infers Result<User, ValidationError|NotFoundError>
-$user = validateUserId($request['id'])
-    ->andThen(findUserById(...));
+/** @return Result<string, NotFoundError> */
+function findUserNameById(int $id): Result
+{
+    return $id === 42 ? new Ok('Alice') : new Err(new NotFoundError());
+}
+
+// PHPStan infers Result<string, ValidationError|NotFoundError>
+$userName = validateUserId('42')->andThen(findUserNameById(...));
+echo $userName->unwrap(); // "Alice"
 ```
 
 ### Combining Results

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ $result = (new Ok(2))
 echo $result->unwrapErr(); // "Too small"
 ```
 
+Each step in a chain may fail with a **different error type**. The error types
+are composed into a union, so PHPStan tracks every error the chain can produce:
+
+```php
+/** @return Result<UserId, ValidationError> */
+function validateUserId(string $raw): Result { /* ... */ }
+
+/** @return Result<User, NotFoundError> */
+function findUserById(UserId $id): Result { /* ... */ }
+
+// PHPStan infers Result<User, ValidationError|NotFoundError>
+$user = validateUserId($request['id'])
+    ->andThen(findUserById(...));
+```
+
 ### Combining Results
 
 ```php
@@ -113,6 +128,30 @@ $result = (new Ok(42))
 $result = (new Err("oops"))
     ->inspectErr(fn($e) => error_log("Error occurred: $e"));
 ```
+
+## Type Safety
+
+This library is designed to be used with [PHPStan](https://phpstan.org/) at level max
+and leans on several of its generics features:
+
+- **Sealed interface** — `Result` is annotated with `@phpstan-sealed Ok|Err`, so
+  PHPStan knows `Ok` and `Err` are the only implementations. A `match (true)` over
+  `instanceof` checks is recognized as exhaustive, and the `else` branch of an
+  `instanceof Ok` check narrows to `Err`.
+- **Covariant type parameters** — `T` and `E` are declared `@template-covariant`,
+  so `Ok<T>` (which is `Result<T, never>`) and `Err<E>` (which is `Result<never, E>`)
+  are assignable to any `Result<T, E>`. A function declared to return
+  `Result<User, DbError>` can simply `return new Ok($user);`.
+- **Error-type composition** — `andThen()`/`and()` widen the error channel to
+  `E|F` and `orElse()`/`or()` widen the success channel to `T|U`, so chains that
+  mix failure types stay precisely typed.
+- **Type narrowing** — `isOk()`/`isErr()` narrow `$result` to `Ok<T>`/`Err<E>`
+  via `@phpstan-assert-if-true`, and `unwrap()`/`unwrapErr()`/`unwrapOr()` use
+  conditional return types (`never` on the impossible side).
+
+Note: because the templates are covariant, PHPStan preserves constant value types
+(`new Ok(10)` is `Ok<10>`, not `Ok<int>`). Type a variable or parameter as `int`
+if you want the widened type.
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,15 @@ and leans on several of its generics features:
   `Result<User, DbError>` can simply `return new Ok($user);`.
 - **Error-type composition** — `andThen()`/`and()` widen the error channel to
   `E|F` and `orElse()`/`or()` widen the success channel to `T|U`, so chains that
-  mix failure types stay precisely typed.
+  mix failure types stay precisely typed. (This deliberately diverges from Rust,
+  whose `and`/`or` family keeps the other channel's type fixed.)
 - **Type narrowing** — `isOk()`/`isErr()` narrow `$result` to `Ok<T>`/`Err<E>`
-  via `@phpstan-assert-if-true`, and `unwrap()`/`unwrapErr()`/`unwrapOr()` use
-  conditional return types (`never` on the impossible side).
+  via `@phpstan-assert-if-true`; `unwrap()`/`unwrapErr()` use conditional return
+  types (`never` on the impossible side), and `unwrapOr()`/`unwrapOrElse()`
+  resolve to `T` on `Ok` and to the default's type on `Err`.
+- **Precise concrete receivers** — when the receiver is statically `Ok<T>` or
+  `Err<E>`, no-op methods keep their exact type (`$ok->orElse(...)` stays
+  `Ok<T>`, `$err->andThen(...)` stays `Err<E>`) instead of widening to a union.
 
 Note: because the templates are covariant, PHPStan preserves constant value types
 (`new Ok(10)` is `Ok<10>`, not `Ok<int>`). Type a variable or parameter as `int`

--- a/src/Err.php
+++ b/src/Err.php
@@ -9,7 +9,7 @@ use Override;
 /**
  * Err はエラー値を表します.
  *
- * @template E
+ * @template-covariant E
  *
  * @implements Result<never, E>
  */

--- a/src/Err.php
+++ b/src/Err.php
@@ -86,24 +86,40 @@ final readonly class Err implements Result
         return $fn($this->value);
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function map(callable $fn): Result
     {
         return $this;
     }
 
+    /**
+     * @template F
+     *
+     * @param callable(E): F $fn
+     *
+     * @return Err<F>
+     */
     #[Override]
     public function mapErr(callable $fn): Result
     {
         return new self($fn($this->value));
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function inspect(callable $fn): Result
     {
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function inspectErr(callable $fn): Result
     {
@@ -112,24 +128,48 @@ final readonly class Err implements Result
         return $this;
     }
 
+    /**
+     * @template U
+     * @template V
+     *
+     * @param U $default
+     * @param callable(never): V $fn
+     *
+     * @return U
+     */
     #[Override]
     public function mapOr(mixed $default, callable $fn): mixed
     {
         return $default;
     }
 
+    /**
+     * @template U
+     * @template V
+     *
+     * @param callable(): U $default_fn
+     * @param callable(never): V $fn
+     *
+     * @return U
+     */
     #[Override]
     public function mapOrElse(callable $default_fn, callable $fn): mixed
     {
         return $default_fn();
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function and(Result $res): Result
     {
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function andThen(callable $fn): Result
     {

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -85,18 +85,31 @@ final readonly class Ok implements Result
         return $this->value;
     }
 
+    /**
+     * @template U
+     *
+     * @param callable(T): U $fn
+     *
+     * @return Ok<U>
+     */
     #[Override]
     public function map(callable $fn): Result
     {
         return new self($fn($this->value));
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function mapErr(callable $fn): Result
     {
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function inspect(callable $fn): Result
     {
@@ -105,6 +118,9 @@ final readonly class Ok implements Result
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function inspectErr(callable $fn): Result
     {
@@ -113,8 +129,9 @@ final readonly class Ok implements Result
 
     /**
      * @template U
+     * @template V
      *
-     * @param U $default
+     * @param V $default
      * @param callable(T): U $fn
      *
      * @return U
@@ -127,8 +144,9 @@ final readonly class Ok implements Result
 
     /**
      * @template U
+     * @template V
      *
-     * @param callable(): U $default_fn
+     * @param callable(): V $default_fn
      * @param callable(T): U $fn
      *
      * @return U
@@ -151,12 +169,18 @@ final readonly class Ok implements Result
         return $fn($this->value);
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function or(Result $res): Result
     {
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     #[Override]
     public function orElse(callable $fn): Result
     {

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -9,7 +9,7 @@ use Override;
 /**
  * Ok は成功値を表します.
  *
- * @template T
+ * @template-covariant T
  *
  * @implements Result<T, never>
  */
@@ -63,7 +63,8 @@ final readonly class Ok implements Result
     }
 
     /**
-     * @param T $default
+     * @template U
+     * @param U $default
      * @return T
      */
     #[Override]

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,8 +7,10 @@ namespace Valbeat\Result;
 /**
  * Result型は、成功（Ok）または失敗（Err）を表現します。
  *
- * @template T 成功時の値の型
- * @template E 失敗時のエラーの型
+ * @template-covariant T 成功時の値の型
+ * @template-covariant E 失敗時のエラーの型
+ *
+ * @phpstan-sealed Ok|Err
  */
 interface Result
 {
@@ -53,14 +55,14 @@ interface Result
     /**
      * 成功値を返します。失敗の場合は例外を投げます.
      *
-     * @return ($this is Ok<T> ? T : never)
+     * @return ($this is Ok<mixed> ? T : never)
      */
     public function unwrap(): mixed;
 
     /**
      * エラー値を返します。成功の場合は例外を投げます.
      *
-     * @return ($this is Err<E> ? E : never)
+     * @return ($this is Err<mixed> ? E : never)
      */
     public function unwrapErr(): mixed;
 
@@ -69,7 +71,7 @@ interface Result
      *
      * @template U
      * @param U $default
-     * @return ($this is Ok<T> ? T : U)
+     * @return ($this is Ok<mixed> ? T : U)
      */
     public function unwrapOr(mixed $default): mixed;
 
@@ -79,7 +81,7 @@ interface Result
      * @template U
      * @param callable(E): U $fn
      *
-     * @return T|U
+     * @return ($this is Ok<mixed> ? T : U)
      */
     public function unwrapOrElse(callable $fn): mixed;
 
@@ -131,7 +133,7 @@ interface Result
      * @param U $default
      * @param callable(T): U $fn
      *
-     * @return T|U
+     * @return U
      */
     public function mapOr(mixed $default, callable $fn): mixed;
 
@@ -151,43 +153,51 @@ interface Result
      * 成功の場合は第2の結果を返し、失敗の場合は最初のエラーを返します.
      *
      * @template U
+     * @template F
      *
-     * @param Result<U, E> $res
+     * @param Result<U, F> $res
      *
-     * @return Result<U, E>
+     * @return Result<U, E|F>
      */
     public function and(self $res): self;
 
     /**
      * 成功の場合は関数を適用し、失敗の場合は現在のエラーを返します.
      *
+     * 関数は元と異なるエラー型を返せます。エラー型は E|F に合成されます.
+     *
      * @template U
+     * @template F
      *
-     * @param callable(T): Result<U, E> $fn
+     * @param callable(T): Result<U, F> $fn
      *
-     * @return Result<U, E>
+     * @return Result<U, E|F>
      */
     public function andThen(callable $fn): self;
 
     /**
      * 失敗の場合は第2の結果を返し、成功の場合は最初の値を返します.
      *
+     * @template U
      * @template F
      *
-     * @param Result<T, F> $res
+     * @param Result<U, F> $res
      *
-     * @return Result<T, F>
+     * @return Result<T|U, F>
      */
     public function or(self $res): self;
 
     /**
      * 失敗の場合は関数を適用し、成功の場合は現在の値を返します.
      *
+     * 関数は元と異なる成功型を返せます。成功型は T|U に合成されます.
+     *
+     * @template U
      * @template F
      *
-     * @param callable(E): Result<T, F> $fn
+     * @param callable(E): Result<U, F> $fn
      *
-     * @return Result<T, F>
+     * @return Result<T|U, F>
      */
     public function orElse(callable $fn): self;
 

--- a/tests/ErrTest.php
+++ b/tests/ErrTest.php
@@ -36,7 +36,7 @@ class ErrTest extends TestCase
     #[Test]
     public function isErrAnd_whenCallbackReturnsTrue_returns_true(): void
     {
-        $err = new Err('critical');
+        $err = new Err(self::asString('critical'));
         $result = $err->isErrAnd(fn ($error) => $error === 'critical');
         $this->assertTrue($result);
     }
@@ -44,7 +44,7 @@ class ErrTest extends TestCase
     #[Test]
     public function isErrAnd_whenCallbackReturnsFalse_returns_false(): void
     {
-        $err = new Err('warning');
+        $err = new Err(self::asString('warning'));
         $result = $err->isErrAnd(fn ($error) => $error === 'critical');
         $this->assertFalse($result);
     }
@@ -114,7 +114,7 @@ class ErrTest extends TestCase
     #[Test]
     public function unwrapOrElse_receives_error_value(): void
     {
-        $err = new Err(404);
+        $err = new Err(self::asInt(404));
         $result = $err->unwrapOrElse(fn ($code) => $code === 404 ? 'Not Found' : 'Unknown');
         $this->assertSame('Not Found', $result);
     }
@@ -313,5 +313,21 @@ class ErrTest extends TestCase
 
         $handled = $err->mapErr(fn ($e) => $e->getMessage());
         $this->assertSame('Something went wrong', $handled->unwrapErr());
+    }
+
+    /**
+     * リテラル型を int に広げます（共変テンプレートは定数型を保持するため）.
+     */
+    private static function asInt(int $value): int
+    {
+        return $value;
+    }
+
+    /**
+     * リテラル型を string に広げます（共変テンプレートは定数型を保持するため）.
+     */
+    private static function asString(string $value): string
+    {
+        return $value;
     }
 }

--- a/tests/ErrTest.php
+++ b/tests/ErrTest.php
@@ -216,6 +216,16 @@ class ErrTest extends TestCase
     }
 
     #[Test]
+    public function andThen_withDifferentErrorType_keeps_original_error(): void
+    {
+        $err = new Err(self::asString('validation failed'));
+        $result = $err->andThen(fn ($x) => new Err(new \DomainException('unreachable')));
+
+        $this->assertSame($err, $result);
+        $this->assertSame('validation failed', $result->unwrapErr());
+    }
+
+    #[Test]
     public function or_withAnotherErr_returns_second_err(): void
     {
         $err1 = new Err('error1');
@@ -232,6 +242,16 @@ class ErrTest extends TestCase
         $result = $err->orElse(fn ($code) => new Err("HTTP Error: $code"));
         $this->assertInstanceOf(Err::class, $result);
         $this->assertSame('HTTP Error: 404', $result->unwrapErr());
+    }
+
+    #[Test]
+    public function orElse_withDifferentSuccessType_recovers(): void
+    {
+        $err = new Err(self::asString('original'));
+        $result = $err->orElse(fn ($e) => new Ok(\strlen($e)));
+
+        $this->assertInstanceOf(Ok::class, $result);
+        $this->assertSame(8, $result->unwrap());
     }
 
     #[Test]

--- a/tests/OkTest.php
+++ b/tests/OkTest.php
@@ -28,7 +28,7 @@ class OkTest extends TestCase
     #[Test]
     public function isOkAnd_whenCallbackReturnsTrue_returns_true(): void
     {
-        $ok = new Ok(10);
+        $ok = new Ok(self::asInt(10));
         $result = $ok->isOkAnd(fn ($value) => $value > 5);
         $this->assertTrue($result);
     }
@@ -36,7 +36,7 @@ class OkTest extends TestCase
     #[Test]
     public function isOkAnd_whenCallbackReturnsFalse_returns_false(): void
     {
-        $ok = new Ok(3);
+        $ok = new Ok(self::asInt(3));
         $result = $ok->isOkAnd(fn ($value) => $value > 5);
         $this->assertFalse($result);
     }
@@ -285,5 +285,13 @@ class OkTest extends TestCase
 
         $this->assertInstanceOf(Ok::class, $result);
         $this->assertSame(22, $result->unwrap()); // (10 * 2) + 5 - 3 = 22
+    }
+
+    /**
+     * リテラル型を int に広げます（共変テンプレートは定数型を保持するため）.
+     */
+    private static function asInt(int $value): int
+    {
+        return $value;
     }
 }

--- a/tests/OkTest.php
+++ b/tests/OkTest.php
@@ -191,6 +191,32 @@ class OkTest extends TestCase
     }
 
     #[Test]
+    public function andThen_withDifferentErrorType_chains_results(): void
+    {
+        $ok = new Ok(self::asInt(10));
+        $result = $ok->andThen(
+            fn ($x) => $x > 5 ? new Ok("value: $x") : new Err(new \DomainException('too small')),
+        );
+
+        $this->assertInstanceOf(Ok::class, $result);
+        $this->assertSame('value: 10', $result->unwrap());
+    }
+
+    #[Test]
+    public function andThen_withDifferentErrorType_returns_new_err(): void
+    {
+        $ok = new Ok(self::asInt(3));
+        $result = $ok->andThen(
+            fn ($x) => $x > 5 ? new Ok("value: $x") : new Err(new \DomainException('too small')),
+        );
+
+        $this->assertInstanceOf(Err::class, $result);
+        $error = $result->unwrapErr();
+        $this->assertInstanceOf(\DomainException::class, $error);
+        $this->assertSame('too small', $error->getMessage());
+    }
+
+    #[Test]
     public function or_returns_self(): void
     {
         $ok1 = new Ok(42);

--- a/tests/Types/result.php
+++ b/tests/Types/result.php
@@ -124,6 +124,17 @@ function testExhaustiveMatch(Result $result): string
 }
 
 /**
+ * ネストした Result の平坦化: andThen が内側の成功型と両エラー型の合成を推論できる.
+ *
+ * @param Result<Result<int, RuntimeException>, LogicException> $nested
+ */
+function testNestedResultFlattening(Result $nested): void
+{
+    $flattened = $nested->andThen(static fn (Result $inner): Result => $inner);
+    assertType('Valbeat\Result\Result<int, LogicException|RuntimeException>', $flattened);
+}
+
+/**
  * 具象 Ok レシーバでは no-op 側のメソッドが実行時に起こり得ない型を混ぜない.
  *
  * @param Ok<int> $ok

--- a/tests/types/result.php
+++ b/tests/types/result.php
@@ -123,6 +123,44 @@ function testExhaustiveMatch(Result $result): string
     };
 }
 
+/**
+ * 具象 Ok レシーバでは no-op 側のメソッドが実行時に起こり得ない型を混ぜない.
+ *
+ * @param Ok<int> $ok
+ */
+function testConcreteOkPrecision(Ok $ok): void
+{
+    // or/orElse は $this を返すため Ok<int> のまま
+    assertType('Valbeat\Result\Ok<int>', $ok->orElse(static fn (never $e): Result => findNameById(0)));
+    assertType('Valbeat\Result\Ok<int>', $ok->or(findNameById(0)));
+    // mapErr は no-op
+    assertType('Valbeat\Result\Ok<int>', $ok->mapErr(static fn (never $e): LogicException => $e));
+    // map は Ok<U> を返す
+    assertType('Valbeat\Result\Ok<string>', $ok->map(stringify(...)));
+    // mapOr/mapOrElse は常に $fn の結果（デフォルト値の型は混ざらない）
+    assertType('string', $ok->mapOr(0.5, stringify(...)));
+    assertType('string', $ok->mapOrElse(static fn (): float => 0.5, stringify(...)));
+}
+
+/**
+ * 具象 Err レシーバでは no-op 側のメソッドが実行時に起こり得ない型を混ぜない.
+ *
+ * @param Err<RuntimeException> $err
+ */
+function testConcreteErrPrecision(Err $err, float $fallback): void
+{
+    // and/andThen は $this を返すため Err<RuntimeException> のまま
+    assertType('Valbeat\Result\Err<RuntimeException>', $err->andThen(static fn (never $v): Result => findNameById(0)));
+    assertType('Valbeat\Result\Err<RuntimeException>', $err->and(findNameById(0)));
+    // map は no-op
+    assertType('Valbeat\Result\Err<RuntimeException>', $err->map(static fn (never $v): int => $v));
+    // mapErr は Err<F> を返す
+    assertType('Valbeat\Result\Err<LogicException>', $err->mapErr(static fn (RuntimeException $e): LogicException => new LogicException($e->getMessage())));
+    // mapOr/mapOrElse は常にデフォルト側（$fn の戻り値型は混ざらない）
+    assertType('float', $err->mapOr($fallback, static fn (never $v): string => $v));
+    assertType('float', $err->mapOrElse(static fn (): float => $fallback, static fn (never $v): string => $v));
+}
+
 function stringify(int $value): string
 {
     return 'value: ' . $value;

--- a/tests/types/result.php
+++ b/tests/types/result.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Valbeat\Result\Tests\Types;
+
+use LogicException;
+
+use function PHPStan\Testing\assertType;
+
+use RuntimeException;
+use Valbeat\Result\Err;
+use Valbeat\Result\Ok;
+
+use Valbeat\Result\Result;
+
+/**
+ * 共変性のテスト: Ok<int> (= Result<int, never>) を
+ * Result<int, RuntimeException> として返せる.
+ *
+ * @return Result<int, RuntimeException>
+ */
+function parsePositiveInt(string $input): Result
+{
+    $value = (int) $input;
+    if ($value > 0) {
+        return new Ok($value);
+    }
+
+    return new Err(new RuntimeException('not a positive int'));
+}
+
+/**
+ * @return Result<string, LogicException>
+ */
+function findNameById(int $id): Result
+{
+    if ($id === 42) {
+        return new Ok('Alice');
+    }
+
+    return new Err(new LogicException('not found'));
+}
+
+/**
+ * @param Result<int, RuntimeException> $result
+ */
+function testAndThenComposesErrorTypes(Result $result): void
+{
+    // andThen は異なるエラー型を返すコールバックを受け取れ、エラー型は E|F に合成される
+    $chained = $result->andThen(findNameById(...));
+    assertType('Valbeat\Result\Result<string, LogicException|RuntimeException>', $chained);
+}
+
+/**
+ * @param Result<int, RuntimeException> $result
+ * @param Result<string, LogicException> $other
+ */
+function testAndComposesErrorTypes(Result $result, Result $other): void
+{
+    assertType('Valbeat\Result\Result<string, LogicException|RuntimeException>', $result->and($other));
+}
+
+/**
+ * @param Result<int, RuntimeException> $result
+ */
+function testOrElseComposesSuccessTypes(Result $result): void
+{
+    // orElse は異なる成功型を返すコールバックを受け取れ、成功型は T|U に合成される
+    $recovered = $result->orElse(static fn (RuntimeException $e): Result => findNameById(0));
+    assertType('Valbeat\Result\Result<int|string, LogicException>', $recovered);
+}
+
+/**
+ * @param Result<int, RuntimeException> $result
+ * @param Result<string, LogicException> $other
+ */
+function testOrComposesSuccessTypes(Result $result, Result $other): void
+{
+    assertType('Valbeat\Result\Result<int|string, LogicException>', $result->or($other));
+}
+
+/**
+ * @param Result<int, RuntimeException> $result
+ */
+function testIsOkNarrowing(Result $result): void
+{
+    if ($result->isOk()) {
+        assertType('Valbeat\Result\Ok<int>', $result);
+        assertType('int', $result->unwrap());
+    } else {
+        assertType('Valbeat\Result\Err<RuntimeException>', $result);
+        assertType('RuntimeException', $result->unwrapErr());
+    }
+}
+
+/**
+ * sealed のテスト: instanceof Ok の else 分岐で Err に絞り込まれる.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testInstanceofNarrowing(Result $result): bool
+{
+    if ($result instanceof Ok) {
+        assertType('Valbeat\Result\Ok<int>', $result);
+
+        return true;
+    }
+    assertType('Valbeat\Result\Err<RuntimeException>', $result);
+
+    return false;
+}
+
+function stringify(int $value): string
+{
+    return 'value: ' . $value;
+}
+
+/**
+ * @param Result<int, RuntimeException> $result
+ */
+function testUnwrapVariants(Result $result, string $default, float $fallback): void
+{
+    assertType('int|string', $result->unwrapOr($default));
+    assertType('float|int', $result->unwrapOrElse(static fn (RuntimeException $e): float => $fallback));
+    assertType('string', $result->mapOr($default, stringify(...)));
+}
+
+/**
+ * @param Result<int, RuntimeException> $result
+ */
+function testMap(Result $result): void
+{
+    assertType(
+        'Valbeat\Result\Result<string, RuntimeException>',
+        $result->map(stringify(...)),
+    );
+    assertType(
+        'Valbeat\Result\Result<int, LogicException>',
+        $result->mapErr(static fn (RuntimeException $e): LogicException => new LogicException($e->getMessage())),
+    );
+}

--- a/tests/types/result.php
+++ b/tests/types/result.php
@@ -102,13 +102,25 @@ function testIsOkNarrowing(Result $result): void
 function testInstanceofNarrowing(Result $result): bool
 {
     if ($result instanceof Ok) {
-        assertType('Valbeat\Result\Ok<int>', $result);
-
         return true;
     }
-    assertType('Valbeat\Result\Err<RuntimeException>', $result);
+    // sealed の効果: instanceof Ok の else 分岐で Err に絞り込まれる
+    assertType('Valbeat\Result\Err', $result);
 
     return false;
+}
+
+/**
+ * sealed の効果: Ok と Err で全ケース網羅と判断され、match が非網羅エラーにならない.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testExhaustiveMatch(Result $result): string
+{
+    return match (true) {
+        $result instanceof Ok => 'ok',
+        $result instanceof Err => 'err',
+    };
 }
 
 function stringify(int $value): string


### PR DESCRIPTION
## 概要

以下の記事で紹介されている PHPStan テクニックを取り込み、型注釈を改良します。

- https://zenn.dev/higaki/articles/my-php-result-type
- https://zenn.dev/higaki/articles/my-php-result-type-more

変更はすべて PHPDoc レベルでランタイム挙動は不変です（型の緩和方向なので後方互換）。

## 変更内容

### `@phpstan-sealed Ok|Err`（記事1）
`Result` の実装を `Ok`/`Err` に限定。`instanceof` ベースの `match (true)` が網羅的と判定され、`instanceof Ok` の else 分岐が `Err` に絞り込まれます。

### `@template-covariant T` / `@template-covariant E`（記事1）
`Ok<T>` (= `Result<T, never>`) と `Err<E>` (= `Result<never, E>`) が任意の `Result<T, E>` に代入可能になり、`@return Result<User, DbError>` の関数で `return new Ok($user);` がそのまま通ります。

### エラー型の合成（記事2）
- `andThen()` / `and()`: コールバック・引数が異なるエラー型 `F` を持てるようになり、戻り値は `Result<U, E|F>`
- `orElse()` / `or()`: 異なる成功型 `U` を許容し、戻り値は `Result<T|U, F>`

```php
// PHPStan が Result<User, ValidationError|NotFoundError> と推論
$user = validateUserId($request['id'])
    ->andThen(findUserById(...));
```

### 付随する型精度の修正
- `mapOr()` の戻り値を `U` に修正（従来の `T|U` は不正確）
- `unwrapOrElse()` を条件付き戻り値型 `($this is Ok<mixed> ? T : U)` に
- 条件付き戻り値型の条件を `Ok<T>` → `Ok<mixed>` に変更（共変テンプレートが不変位置に出現しないように）

### テスト
- `tests/types/result.php` を新規追加: `PHPStan\Testing\assertType()` による型レベルテスト（`composer phpstan` で検証される）
- 異なる型を合成するチェーンのユニットテストを追加（69 tests / 111 assertions）
- 共変化により定数型が保持される（`new Ok(10)` が `Ok<10>`）ため、既存テストのリテラル比較が alwaysTrue/alwaysFalse になる箇所をヘルパーで widening

## 検証

- `composer phpstan` (level max): No errors
- `phpunit`: OK (69 tests, 111 assertions)
- `composer cs-check`: パス

> [!NOTE]
> `@phpstan-sealed` は phpstan 2.1.54（composer.json の固定バージョン）で利用可能です。ローカルの vendor が古い場合は `composer update` が必要です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* 型安全性についてのドキュメントを新設し、エラー型合成、型ナローイング、値型保持などの機能を説明しました。

## Tests
* エラー型合成とエラー回復のテストケースを追加。型推論の正確性を検証するテストも新たに実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 互換性への影響（静的解析レベル）

ランタイムは無変更ですが、PHPStan を使う利用側には以下の影響があり得ます:

- **`@phpstan-sealed` による実装制限**: `Result` を独自実装している downstream コードは、アップグレード後に PHPStan エラーになります（Ok/Err 以外の実装を意図的に禁止するための変更です）
- **定数型の保持**: 共変化により `new Ok(10)` が `Ok<10>` と推論されるため、level max ではリテラル比較が `alwaysTrue/alwaysFalse` として新たに検出されることがあります（README の Type Safety セクションに対処法を記載）

## セルフレビューでの追加修正

- 具象 `Ok<T>`/`Err<E>` レシーバで no-op メソッドが型を過剰に広げる問題を修正（`$ok->orElse(...)` が `Result<int|string, never>` でなく `Ok<int>` のままになるよう、クラス別オーバーライドを追加）
- README の不正確な記述を修正（`unwrapOr` の Err 側は `never` でなくデフォルト値の型）
- `and`/`or` 系のチャネル合成が Rust からの意図的な逸脱であることを README に明記
