### PR TITLE
feat: add PHP 8.5 support

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        php-version: ['8.4']
+        php-version: ['8.4', '8.5']
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        php-version: ['8.4']
+        php-version: ['8.4', '8.5']
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.4']
+        php: ['8.4', '8.5']
 
     steps:
       - name: Checkout
@@ -50,6 +50,7 @@ jobs:
             --colors=always
 
       - name: Upload coverage to Codecov
+        if: matrix.php == '8.5'
         uses: codecov/codecov-action@v5
         with:
           files: build/logs/clover.xml
@@ -58,7 +59,7 @@ jobs:
           verbose: true
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.php == '8.5' }}
         uses: codecov/test-results-action@v1
         with:
           files: build/logs/junit.xml

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require valbeat/result
 
 ## Requirements
 
-- PHP 8.4 or higher
+- PHP 8.4 or higher (tested on PHP 8.4 and 8.5)
 - Composer
 
 ## Basic Usage

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,5 +13,7 @@ parameters:
     checkBenevolentUnionTypes: true
     checkUninitializedProperties: true
     
-    # PHP 8.4 features
-    phpVersion: 80400
+    # Supported PHP versions (8.4 - 8.5)
+    phpVersion:
+        min: 80400
+        max: 80500


### PR DESCRIPTION
## Summary

Add PHP 8.5 support to the CI pipeline while keeping PHP 8.4 supported (`composer.json` constraint `^8.4` already allows 8.5, so no change there).

## Changes

- **CI workflows** (`test.yml`, `phpstan.yml`, `code-style.yml`): add `'8.5'` to the PHP version matrix — each workflow now runs on both 8.4 and 8.5
- **`test.yml`**: upload coverage and test results to Codecov only from the PHP 8.5 job to avoid duplicate uploads across matrix entries
- **`phpstan.neon`**: widen `phpVersion` from `80400` to a `min: 80400 / max: 80500` range so analysis covers both supported versions
- **`README.md`**: document tested PHP versions (8.4 / 8.5)

## Notes

- No source code changes needed: `src/` only uses features stable on 8.5 (readonly classes, `#[Override]`, `never` types) with no deprecations
- Dev dependencies (phpstan 2.2.2, phpunit 12.5.8, php-cs-fixer 3.95.4) all support PHP 8.5

## Verification

- Local (PHP 8.4.7): `composer phpstan` ✅ / `composer cs-check` ✅ / `phpunit --no-coverage` ✅ (69 tests, 111 assertions)
- CI: expect 6 green jobs (8.4 × 3 + 8.5 × 3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * PHP 8.5 のサポートを追加しました
  * GitHub Actions ワークフローを拡張し、PHP 8.4 と 8.5 の両バージョンでテストと静的解析を実行するよう変更しました
  * プロジェクトドキュメントとツール設定を最新化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->