### PR TITLE
test: add assertType coverage for untested type inference cases

### DIFF
--- a/tests/Types/result.php
+++ b/tests/Types/result.php
@@ -95,6 +95,36 @@ function testIsOkNarrowing(Result $result): void
 }
 
 /**
+ * isErr によるナローイング: true 側で Err、false 側で Ok に絞り込まれる.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testIsErrNarrowing(Result $result): void
+{
+    if ($result->isErr()) {
+        assertType('Valbeat\Result\Err<RuntimeException>', $result);
+        assertType('RuntimeException', $result->unwrapErr());
+    } else {
+        assertType('Valbeat\Result\Ok<int>', $result);
+        assertType('int', $result->unwrap());
+    }
+}
+
+/**
+ * 既知の制限: instanceof Ok の true 側分岐ではジェネリクスが失われ、unwrap は mixed になる.
+ * 型引数を保ったまま絞り込みたい場合は isOk() / isErr() を使う（testIsOkNarrowing 参照）.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testInstanceofOkNarrowing(Result $result): void
+{
+    if ($result instanceof Ok) {
+        assertType('Valbeat\Result\Ok', $result);
+        assertType('mixed', $result->unwrap());
+    }
+}
+
+/**
  * sealed のテスト: instanceof Ok の else 分岐で Err に絞り込まれる.
  *
  * @param Result<int, RuntimeException> $result
@@ -121,6 +151,123 @@ function testExhaustiveMatch(Result $result): string
         $result instanceof Ok => 'ok',
         $result instanceof Err => 'err',
     };
+}
+
+/**
+ * 既知の制限: match 式の instanceof アームではジェネリクスが失われ mixed になる.
+ * 型引数を保ちたい場合は isOk() アームを使う（testMatchArmNarrowingWithIsOk 参照）.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testMatchArmNarrowing(Result $result): void
+{
+    $value = match (true) {
+        $result instanceof Ok => $result->unwrap(),
+        $result instanceof Err => $result->unwrapErr(),
+    };
+    assertType('mixed', $value);
+}
+
+/**
+ * match 式のアーム内ナローイング: isOk() でも assert-if-true が効く.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testMatchArmNarrowingWithIsOk(Result $result): void
+{
+    $value = match (true) {
+        $result->isOk() => $result->unwrap(),
+        default => $result->unwrapErr(),
+    };
+    assertType('int|RuntimeException', $value);
+}
+
+/**
+ * match() メソッドの戻り値は両コールバックの戻り値型 U|V に合成される.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testMatchMethodComposesReturnTypes(Result $result, float $fallback): void
+{
+    $value = $result->match(
+        stringify(...),
+        static fn (RuntimeException $e): float => $fallback,
+    );
+    assertType('float|string', $value);
+}
+
+/**
+ * inspect / inspectErr は型を変えない.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testInspectPreservesType(Result $result): void
+{
+    assertType('Valbeat\Result\Result<int, RuntimeException>', $result->inspect(static function (int $v): void {
+    }));
+    assertType('Valbeat\Result\Result<int, RuntimeException>', $result->inspectErr(static function (RuntimeException $e): void {
+    }));
+}
+
+/**
+ * isOkAnd / isErrAnd / inspect のコールバック引数の型が推論される.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testCallbackParamInference(Result $result): void
+{
+    $result->isOkAnd(static function ($value): bool {
+        assertType('int', $value);
+
+        return true;
+    });
+    $result->isErrAnd(static function ($error): bool {
+        assertType('RuntimeException', $error);
+
+        return true;
+    });
+    $result->inspect(static function ($value): void {
+        assertType('int', $value);
+    });
+    $result->inspectErr(static function ($error): void {
+        assertType('RuntimeException', $error);
+    });
+}
+
+/**
+ * コンストラクタからの型推論: new Ok / new Err で型引数が決まる.
+ */
+function testConstructorInference(int $value, RuntimeException $error): void
+{
+    assertType('Valbeat\Result\Ok<int>', new Ok($value));
+    assertType('Valbeat\Result\Err<RuntimeException>', new Err($error));
+}
+
+/**
+ * ジェネリック Result レシーバでの unwrap / unwrapErr は条件付き戻り値型が解決される.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testUnwrapOnGenericReceiver(Result $result): void
+{
+    assertType('int', $result->unwrap());
+    assertType('RuntimeException', $result->unwrapErr());
+}
+
+/**
+ * 具象レシーバでの unwrapOr / unwrapOrElse: 実行時に起こり得ない側の型を混ぜない.
+ *
+ * @param Ok<int> $ok
+ * @param Err<RuntimeException> $err
+ */
+function testConcreteUnwrapVariants(Ok $ok, Err $err, string $default, float $fallback): void
+{
+    assertType('int', $ok->unwrap());
+    assertType('int', $ok->unwrapOr($default));
+    assertType('int', $ok->unwrapOrElse(static fn (never $e): float => $fallback));
+    assertType('RuntimeException', $err->unwrapErr());
+    assertType('string', $err->unwrapOr($default));
+    assertType('float', $err->unwrapOrElse(static fn (RuntimeException $e): float => $fallback));
 }
 
 /**


### PR DESCRIPTION
## Summary

`tests/Types/result.php` の assertType 型テストを拡充し、アノテーションは実装済みなのに検証されていなかったケース（`isErr()` ナローイング等）と、`match` 式・コールバック推論まわりの未カバーケースを追加する。ライブラリ本体（`src/`）の変更はなし。

## Changes

- **`isErr()` ナローイング**: `@phpstan-assert-if-true Err<E>` / `@phpstan-assert-if-false Ok<T>` の両分岐を検証（これまで `isOk()` 側のみテストされていた）
- **`instanceof` ナローイングの true 側分岐**: 既知の制限としてピン留め — ジェネリクスが失われ `Ok`（型引数なし）になり `unwrap()` は `mixed` になる
- **`match` 式のアーム内ナローイング**: `instanceof` アームでは `mixed` になる一方、`isOk()` アームなら `unwrap()` が `int` に解決されることを対で検証
- **`match()` メソッド**: 戻り値が両コールバックの戻り値型 `U|V`（`float|string`）に合成されることを検証
- **`inspect()` / `inspectErr()`**: `Result<int, RuntimeException>` を変えないことを検証
- **コールバック引数の型推論**: `isOkAnd` / `isErrAnd` / `inspect` / `inspectErr` に渡した型宣言なしクロージャの引数が `int` / `RuntimeException` に推論されることを検証
- **コンストラクタ推論**: `new Ok($int)` → `Ok<int>`、`new Err($e)` → `Err<RuntimeException>`
- **条件付き戻り値型**: ジェネリック `Result` レシーバでの `unwrap()` / `unwrapErr()`、および具象 `Ok` / `Err` レシーバでの `unwrapOr()` / `unwrapOrElse()` が実行時に起こり得ない側の型を混ぜないことを検証

## Notes

- 書き起こしの過程で **`instanceof` ベースの絞り込みはジェネリクスを失う**（`isOk()` / `isErr()` 経由なら保たれる）ことが判明。既存の `testInstanceofNarrowing` が型引数なしの `Err` を期待していたのはこれが理由。該当テストには「既知の制限」コメントを付け、`isOk()` 版の推奨を明記した
- 定数型の一般化されない挙動（`new Ok(42)` → `Ok<42>`、`fn => 0.5` → `0.5`）を避けるため、リテラルではなく引数経由で値を渡している

## Verification

- Local (PHP 8.4.7): `phpstan analyse`（level max）✅ / `php-cs-fixer fix --dry-run` ✅ / `phpunit --no-coverage` ✅ (69 tests, 111 assertions)