### PR TITLE
chore: enable CodeRabbit auto review on draft PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,7 @@ reviews:
 
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
     base_branches:
       - main
 


### PR DESCRIPTION
## Summary

CodeRabbit の自動レビューがドラフトPRでもスキップされず実行されるようにする。

## Changes

- `.coderabbit.yaml`: `reviews.auto_review.drafts` を `false` → `true` に変更

## Notes

- このリポジトリではPRをドラフトで作成する運用のため、`drafts: false` だと作成直後の自動レビューが常に「Review skipped (Draft detected)」になっていた（例: #80）
- ドラフト段階からレビューが不要な場合は、従来どおり `@coderabbitai ignore` で個別に抑制できる