### PR TITLE
docs: document instanceof narrowing limitation, recommend isOk()/isErr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,10 @@ and leans on several of its generics features:
 - **Sealed interface** — `Result` is annotated with `@phpstan-sealed Ok|Err`, so
   PHPStan knows `Ok` and `Err` are the only implementations. A `match (true)` over
   `instanceof` checks is recognized as exhaustive, and the `else` branch of an
-  `instanceof Ok` check narrows to `Err`.
+  `instanceof Ok` check narrows to `Err`. Note that `instanceof` narrowing loses
+  the type arguments (a known PHPStan limitation: `Result<int, E>` narrows to
+  plain `Ok`, so `unwrap()` becomes `mixed`) — use `instanceof` for exhaustiveness
+  checks only, and narrow with `isOk()`/`isErr()` when you need the values.
 - **Covariant type parameters** — `T` and `E` are declared `@template-covariant`,
   so `Ok<T>` (which is `Result<T, never>`) and `Err<E>` (which is `Result<never, E>`)
   are assignable to any `Result<T, E>`. A function declared to return

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,6 +7,10 @@ namespace Valbeat\Result;
 /**
  * Result型は、成功（Ok）または失敗（Err）を表現します。
  *
+ * 注意: instanceof による絞り込みでは型引数が失われます（PHPStan の既知の制限。
+ * Result<int, E> が型引数なしの Ok になり unwrap() は mixed になる）。
+ * 値を取り出す分岐では isOk() / isErr() で絞り込んでください。
+ *
  * @template-covariant T 成功時の値の型
  * @template-covariant E 失敗時のエラーの型
  *


### PR DESCRIPTION
## Summary

`instanceof` ベースの絞り込みでは型引数が失われる（PHPStan の既知の制限）ことを README と `Result` の PHPDoc に明記し、値を取り出す分岐では `isOk()` / `isErr()` を使うよう誘導する。ドキュメントのみの変更。

## Changes

- **`README.md`**: Type Safety セクションの Sealed interface の項に注記を追加 — `instanceof` は網羅性チェックには使えるが、`Result<int, E>` が型引数なしの `Ok` に絞られ `unwrap()` が `mixed` になるため、値の取り出しには `isOk()` / `isErr()` を推奨
- **`src/Result.php`**: インターフェースの class-level PHPDoc に同様の注意書きを追加（PHPDoc のみの変更でコードへの影響なし）

## Notes

- この挙動は #80 の型テスト（`testInstanceofOkNarrowing` / `testMatchArmNarrowing`）で「既知の制限」としてピン留め済み。PHPStan 側が将来改善されればテストが落ちて検知できる
- 既存の README は「`instanceof Ok` の else 分岐は `Err` に絞られる」とだけ書いており、型引数が失われる事実に触れていなかった
- 根本対応は PHPStan 本体の改善待ち。近縁の issue: [phpstan/phpstan#10553](https://github.com/phpstan/phpstan/issues/10553)（open / feature-request）

## Verification

- Local (PHP 8.4.7): `phpstan analyse`（level max）✅ / `php-cs-fixer fix --dry-run` ✅（差分なし）

## Related Issues

Refs #83 — 本制限のトラッキング issue。本PRはそのうち「README / PHPDoc への注記」を担当する。

- 制限の全体像（再現コード・`Ok<int>` への絞り込みが本来 sound である論拠・アップストリーム関連 issue）は #83 を参照
- `Closes` ではなく `Refs` なのは意図的: 根本対応は PHPStan 本体の改善待ちで、修正後に #80 でピン留めした型テストの期待値更新と本注記の削除を行ってからクローズするため（手順は #83 のチェックリストに記載）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 型安全性に関する説明を強化し、PHPStanの型絞り込み動作に関する注意事項と推奨される実装パターンを明確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

