### PR TITLE
docs: document the exhaustiveness vs. generics trade-off in match constructs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,17 @@ and leans on several of its generics features:
   `instanceof Ok` check narrows to `Err`. Note that `instanceof` narrowing loses
   the type arguments (a known PHPStan limitation: `Result<int, E>` narrows to
   plain `Ok`, so `unwrap()` becomes `mixed`), so use `instanceof` in a
-  `match (true)` purely for exhaustiveness. When you also need the values, prefer
-  the `match()` method — it is exhaustive by construction (both arms are required)
-  and keeps `T`/`E` — or narrow with `isOk()`/`isErr()`. (`isOk()`/`isErr()` arms
-  inside a `match (true)` keep the type arguments but are *not* recognized as
-  exhaustive, so they require a `default` arm.)
+  `match (true)` purely for exhaustiveness. When you also need the values, the
+  `match()` method handles both cases and keeps `T`/`E` (it requires both an `ok`
+  and an `err` arm), or narrow with `isOk()`/`isErr()`. These two goals are a
+  trade-off in PHPStan 2.2.2: *enforced* exhaustiveness — where adding a new
+  `Result` variant would turn every unhandled site into an analysis error — comes
+  only from `instanceof` in a `match (true)`, which is exactly the form that drops
+  the type arguments. The `match()` method and `isOk()`/`isErr()` keep the generics
+  but are not checked against variant additions (`isOk()`/`isErr()` arms in a
+  `match (true)` also need a `default`). So per call site you currently pick one:
+  enforced exhaustiveness *or* preserved generics. (In practice `Result` is fixed
+  at `Ok|Err`, so the `match()` method covering both is total for all real cases.)
 - **Covariant type parameters** — `T` and `E` are declared `@template-covariant`,
   so `Ok<T>` (which is `Result<T, never>`) and `Err<E>` (which is `Result<never, E>`)
   are assignable to any `Result<T, E>`. A function declared to return

--- a/README.md
+++ b/README.md
@@ -148,8 +148,12 @@ and leans on several of its generics features:
   `instanceof` checks is recognized as exhaustive, and the `else` branch of an
   `instanceof Ok` check narrows to `Err`. Note that `instanceof` narrowing loses
   the type arguments (a known PHPStan limitation: `Result<int, E>` narrows to
-  plain `Ok`, so `unwrap()` becomes `mixed`) — use `instanceof` for exhaustiveness
-  checks only, and narrow with `isOk()`/`isErr()` when you need the values.
+  plain `Ok`, so `unwrap()` becomes `mixed`), so use `instanceof` in a
+  `match (true)` purely for exhaustiveness. When you also need the values, prefer
+  the `match()` method — it is exhaustive by construction (both arms are required)
+  and keeps `T`/`E` — or narrow with `isOk()`/`isErr()`. (`isOk()`/`isErr()` arms
+  inside a `match (true)` keep the type arguments but are *not* recognized as
+  exhaustive, so they require a `default` arm.)
 - **Covariant type parameters** — `T` and `E` are declared `@template-covariant`,
   so `Ok<T>` (which is `Result<T, never>`) and `Err<E>` (which is `Result<never, E>`)
   are assignable to any `Result<T, E>`. A function declared to return


### PR DESCRIPTION
## 概要

Type Safety セクションの Sealed interface の記述を、`match (true)` における「厳密な網羅性チェック」と「ジェネリクス保持」のトレードオフを正確に説明する内容へ更新しました。

## 背景（PHPStan 2.2.2 で実測）

3つ目の variant を sealed に追加して「未対応ハンドラが静的解析エラーになるか（=厳密な網羅性）」を検証した結果:

| 手法 | 厳密な網羅性<br>（variant 追加で自動エラー） | 型引数の保持 |
|---|---|---|
| `match (true)` + `instanceof` | ✅ 「does not handle remaining value」で検出 | ❌ `Ok` → `unwrap()` が `mixed` |
| `isOk()`/`isErr()` アーム | ❌（`default` 必須で variant 追加を吸収） | ✅ `Ok<int>` |
| `match()` メソッド | ❌ variant 追加を黙って取りこぼす（呼び出し側は無傷） | ✅ `U\|V` |

**厳密な（enforced）網羅性が得られるのは `match (true)` + `instanceof` だけで、それは型引数を失う**ことが確定しました。`match()` メソッドは「現在の2アリティに対して total」ではあるものの、variant 追加に対する自動検出は行いません。

## 変更内容

- Sealed interface の段落に「enforced exhaustiveness と generics 保持は二者択一」というトレードオフを明記
- `Result` は実際には `Ok|Err` の2値固定なので、`match()` メソッドが実用上は全ケースを賄える点も補足

> 当初コミットの「`match()` is exhaustive by construction」は厳密には誤りだったため訂正しています。

ドキュメントのみの変更です。