### PR TITLE
test+docs: error-side exhaustiveness for enum and sealed error types

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ and leans on several of its generics features:
   via `@phpstan-assert-if-true`; `unwrap()`/`unwrapErr()` use conditional return
   types (`never` on the impossible side), and `unwrapOr()`/`unwrapOrElse()`
   resolve to `T` on `Ok` and to the default's type on `Err`.
+- **Exhaustive error matching** — when the error type `E` is a native `enum` or a
+  `@phpstan-sealed` union, the error value can be matched exhaustively (over the
+  enum cases, or `instanceof` arms for a sealed union) and PHPStan enforces it — a
+  missing case becomes an analysis error. Reach the error through `isErr()` +
+  `unwrapErr()`, or the `match()` method's `err` arm; narrowing with
+  `instanceof Err` drops `E` to `mixed` and loses the enum/sealed type (the same
+  `instanceof` limitation as above). The error classes themselves are not generic,
+  so their `instanceof` checks don't suffer the type-argument loss.
 - **Precise concrete receivers** — when the receiver is statically `Ok<T>` or
   `Err<E>`, no-op methods keep their exact type (`$ok->orElse(...)` stays
   `Ok<T>`, `$err->andThen(...)` stays `Err<E>`) instead of widening to a union.

--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ and leans on several of its generics features:
   missing case becomes an analysis error. Reach the error through `isErr()` +
   `unwrapErr()`, or the `match()` method's `err` arm; narrowing with
   `instanceof Err` drops `E` to `mixed` and loses the enum/sealed type (the same
-  `instanceof` limitation as above). The error classes themselves are not generic,
-  so their `instanceof` checks don't suffer the type-argument loss.
+  `instanceof` limitation as above). As long as the error classes are themselves
+  non-generic, their own `instanceof` checks have no type arguments to lose
+  (unlike the generic `Ok`/`Err`).
 - **Precise concrete receivers** — when the receiver is statically `Ok<T>` or
   `Err<E>`, no-op methods keep their exact type (`$ok->orElse(...)` stays
   `Ok<T>`, `$err->andThen(...)` stays `Err<E>`) instead of widening to a union.

--- a/tests/Types/result.php
+++ b/tests/Types/result.php
@@ -348,3 +348,84 @@ function testMap(Result $result): void
         $result->mapErr(static fn (RuntimeException $e): LogicException => new LogicException($e->getMessage())),
     );
 }
+
+/**
+ * エラー側の網羅性テスト用フィクスチャ: native enum.
+ */
+enum HttpError
+{
+    case NotFound;
+    case Forbidden;
+}
+
+/**
+ * エラー側の網羅性テスト用フィクスチャ: @phpstan-sealed なエラー union.
+ *
+ * @phpstan-sealed ValidationFailure|NetworkFailure
+ */
+interface AppError
+{
+}
+
+final class ValidationFailure implements AppError
+{
+}
+
+final class NetworkFailure implements AppError
+{
+}
+
+/**
+ * エラー型が native enum の場合: isErr() 経由なら unwrapErr() が enum 型を保ち、
+ * 全ケースを網羅する match は default なしで網羅と認識される.
+ * （いずれかのケースを落とすと phpstan analyse がエラーになるため、これ自体が網羅性のピン留めになる）
+ *
+ * @param Result<int, HttpError> $result
+ */
+function testEnumErrorExhaustiveness(Result $result): string
+{
+    if ($result->isErr()) {
+        assertType('Valbeat\Result\Tests\Types\HttpError', $result->unwrapErr());
+
+        return match ($result->unwrapErr()) {
+            HttpError::NotFound => 'not found',
+            HttpError::Forbidden => 'forbidden',
+        };
+    }
+
+    return 'ok';
+}
+
+/**
+ * エラー型が @phpstan-sealed union の場合: isErr() 経由で取り出した値に対する
+ * match(true)+instanceof が網羅と認識される（sealed 指定が前提。エラークラスは非ジェネリックなので型引数喪失は起きない）.
+ *
+ * @param Result<int, AppError> $result
+ */
+function testSealedErrorExhaustiveness(Result $result): string
+{
+    if ($result->isErr()) {
+        $error = $result->unwrapErr();
+        assertType('Valbeat\Result\Tests\Types\AppError', $error);
+
+        return match (true) {
+            $error instanceof ValidationFailure => 'validation',
+            $error instanceof NetworkFailure => 'network',
+        };
+    }
+
+    return 'ok';
+}
+
+/**
+ * 既知の落とし穴のピン留め: instanceof Err では E が失われ、enum/sealed であっても
+ * unwrapErr() は mixed になる。値を扱う分岐は isErr() を使う（上の2ケース参照）.
+ *
+ * @param Result<int, HttpError> $result
+ */
+function testInstanceofErrLosesErrorType(Result $result): void
+{
+    if ($result instanceof Err) {
+        assertType('mixed', $result->unwrapErr());
+    }
+}

--- a/tests/Types/result.php
+++ b/tests/Types/result.php
@@ -418,12 +418,25 @@ function testSealedErrorExhaustiveness(Result $result): string
 }
 
 /**
- * 既知の落とし穴のピン留め: instanceof Err では E が失われ、enum/sealed であっても
- * unwrapErr() は mixed になる。値を扱う分岐は isErr() を使う（上の2ケース参照）.
+ * 既知の落とし穴のピン留め（enum エラー）: instanceof Err では E が失われ、
+ * enum であっても unwrapErr() は mixed になる。値を扱う分岐は isErr() を使う（上の2ケース参照）.
  *
  * @param Result<int, HttpError> $result
  */
-function testInstanceofErrLosesErrorType(Result $result): void
+function testInstanceofErrLosesEnumErrorType(Result $result): void
+{
+    if ($result instanceof Err) {
+        assertType('mixed', $result->unwrapErr());
+    }
+}
+
+/**
+ * 既知の落とし穴のピン留め（sealed エラー）: sealed union でも instanceof Err では
+ * E が失われ unwrapErr() は mixed になる.
+ *
+ * @param Result<int, AppError> $result
+ */
+function testInstanceofErrLosesSealedErrorType(Result $result): void
 {
     if ($result instanceof Err) {
         assertType('mixed', $result->unwrapErr());

--- a/tests/Types/result.php
+++ b/tests/Types/result.php
@@ -385,9 +385,10 @@ final class NetworkFailure implements AppError
 function testEnumErrorExhaustiveness(Result $result): string
 {
     if ($result->isErr()) {
-        assertType('Valbeat\Result\Tests\Types\HttpError', $result->unwrapErr());
+        $error = $result->unwrapErr();
+        assertType('Valbeat\Result\Tests\Types\HttpError', $error);
 
-        return match ($result->unwrapErr()) {
+        return match ($error) {
             HttpError::NotFound => 'not found',
             HttpError::Forbidden => 'forbidden',
         };


### PR DESCRIPTION
## 概要

エラー型（`Result<T, E>` の `E`）が native enum / `@phpstan-sealed` union の場合、エラー値を網羅的に分岐できることを **assertType 型テストでピン留め**し、**README にも明記**しました。

## テスト（`tests/Types/result.php`）

フィクスチャ: `HttpError`(enum), `AppError`(`@phpstan-sealed`)・`ValidationFailure`/`NetworkFailure`

| テスト | 検証内容 |
|---|---|
| `testEnumErrorExhaustiveness` | `isErr()` 経由なら `unwrapErr()` が enum 型を保ち、全ケースの `match`（default なし）が網羅と認識される |
| `testSealedErrorExhaustiveness` | sealed union のエラーに対する `match(true)`+`instanceof` が網羅と認識される（エラークラスは非ジェネリックなので型引数喪失なし） |
| `testInstanceofErrLosesErrorType` | 落とし穴のピン留め: `instanceof Err` では E が失われ enum/sealed でも `unwrapErr()` が `mixed` |

厳密性の確認: `HttpError::Forbidden` アームを一時的に外すと `Match expression does not handle remaining value:` で解析エラーになることを確認済み（ケース漏れが検出される＝網羅が強制されている）。

## ドキュメント（`README.md`）

Type Safety セクションに **Exhaustive error matching** の項目を追加:
- `E` が enum / `@phpstan-sealed` union なら、エラー値の網羅分岐を PHPStan が強制する
- エラー値は `isErr()`+`unwrapErr()` か `match()` の `err` アームで取り出す（`instanceof Err` は E を `mixed` に落とすので不可）
- エラークラス自体は非ジェネリックなので、その `instanceof` には型引数喪失は起きない

## 確認

- `phpstan analyse`（level max）: No errors
- `phpunit`: 69 tests OK（既存退行なし）
- `php-cs-fixer --dry-run`: 整形差分なし