### PR TITLE
refactor!: rename callback parameters for named-argument use

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ All Result types (both Ok and Err) implement these methods:
 - `inspectErr(callable $fn): Result` - Calls a function with the error value if Err
 
 #### Pattern Matching
-- `match(callable $okFn, callable $errFn): mixed` - Pattern match on the Result
+- `match(callable $ok, callable $err): mixed` - Pattern match on the Result
 
 ## License
 

--- a/src/Err.php
+++ b/src/Err.php
@@ -147,15 +147,15 @@ final readonly class Err implements Result
      * @template U
      * @template V
      *
-     * @param callable(): U $default_fn
+     * @param callable(): U $defaultFn
      * @param callable(never): V $fn
      *
      * @return U
      */
     #[Override]
-    public function mapOrElse(callable $default_fn, callable $fn): mixed
+    public function mapOrElse(callable $defaultFn, callable $fn): mixed
     {
-        return $default_fn();
+        return $defaultFn();
     }
 
     /**
@@ -189,8 +189,8 @@ final readonly class Err implements Result
     }
 
     #[Override]
-    public function match(callable $ok_fn, callable $err_fn): mixed
+    public function match(callable $ok, callable $err): mixed
     {
-        return $err_fn($this->value);
+        return $err($this->value);
     }
 }

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -146,13 +146,13 @@ final readonly class Ok implements Result
      * @template U
      * @template V
      *
-     * @param callable(): V $default_fn
+     * @param callable(): V $defaultFn
      * @param callable(T): U $fn
      *
      * @return U
      */
     #[Override]
-    public function mapOrElse(callable $default_fn, callable $fn): mixed
+    public function mapOrElse(callable $defaultFn, callable $fn): mixed
     {
         return $fn($this->value);
     }
@@ -188,8 +188,8 @@ final readonly class Ok implements Result
     }
 
     #[Override]
-    public function match(callable $ok_fn, callable $err_fn): mixed
+    public function match(callable $ok, callable $err): mixed
     {
-        return $ok_fn($this->value);
+        return $ok($this->value);
     }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -146,12 +146,12 @@ interface Result
      *
      * @template U
      *
-     * @param callable(): U $default_fn
+     * @param callable(): U $defaultFn
      * @param callable(T): U $fn
      *
      * @return U
      */
-    public function mapOrElse(callable $default_fn, callable $fn): mixed;
+    public function mapOrElse(callable $defaultFn, callable $fn): mixed;
 
     /**
      * 成功の場合は第2の結果を返し、失敗の場合は最初のエラーを返します.
@@ -206,15 +206,15 @@ interface Result
     public function orElse(callable $fn): self;
 
     /**
-     * 成功の場合はok_fnを、失敗の場合はerr_fnを適用します.
+     * 成功の場合はokを、失敗の場合はerrを適用します.
      *
      * @template U
      * @template V
      *
-     * @param callable(T): U $ok_fn 成功値に適用する関数
-     * @param callable(E): V $err_fn エラー値に適用する関数
+     * @param callable(T): U $ok 成功値に適用する関数
+     * @param callable(E): V $err エラー値に適用する関数
      *
      * @return U|V 適用された関数の結果
      */
-    public function match(callable $ok_fn, callable $err_fn): mixed;
+    public function match(callable $ok, callable $err): mixed;
 }

--- a/tests/ErrTest.php
+++ b/tests/ErrTest.php
@@ -277,6 +277,25 @@ class ErrTest extends TestCase
     }
 
     #[Test]
+    public function match_supportsNamedArguments(): void
+    {
+        $err = new Err('error');
+        $result = $err->match(
+            ok: fn ($value) => "Success: $value",
+            err: fn ($error) => "Error: $error",
+        );
+        $this->assertSame('Error: error', $result);
+    }
+
+    #[Test]
+    public function mapOrElse_supportsNamedArguments(): void
+    {
+        $err = new Err('error');
+        $result = $err->mapOrElse(defaultFn: fn () => 100, fn: fn ($x) => $x * 2);
+        $this->assertSame(100, $result);
+    }
+
+    #[Test]
     public function err_withNullValue_handles_null(): void
     {
         $err = new Err(null);

--- a/tests/OkTest.php
+++ b/tests/OkTest.php
@@ -268,6 +268,25 @@ class OkTest extends TestCase
     }
 
     #[Test]
+    public function match_supportsNamedArguments(): void
+    {
+        $ok = new Ok(42);
+        $result = $ok->match(
+            ok: fn ($value) => "Success: $value",
+            err: fn ($error) => "Error: $error",
+        );
+        $this->assertSame('Success: 42', $result);
+    }
+
+    #[Test]
+    public function mapOrElse_supportsNamedArguments(): void
+    {
+        $ok = new Ok(10);
+        $result = $ok->mapOrElse(defaultFn: fn () => 100, fn: fn ($x) => $x * 2);
+        $this->assertSame(20, $result);
+    }
+
+    #[Test]
     public function ok_withNullValue_handles_null(): void
     {
         $ok = new Ok(null);


### PR DESCRIPTION
## 概要

コードレビューで指摘したパラメータ命名の不整合（3 通りの揺れ）を解消します。

- 実装: `$ok_fn` / `$err_fn` / `$default_fn`（snake_case）
- README Basic Usage: `ok:` / `err:`（実行するとフェイタルエラー）
- README API Reference: `$okFn` / `$errFn` / `$defaultFn`（camelCase）

PHP 8.0 以降、パラメータ名は名前付き引数経由で公開 API の一部です。Rust の match アームに合わせて `match(callable $ok, callable $err)`、その他は PHP 標準の camelCase（`$defaultFn`）に統一しました。

## 変更内容

- `match($ok_fn, $err_fn)` → `match($ok, $err)`（Result / Ok / Err）
- `mapOrElse($default_fn, $fn)` → `mapOrElse($defaultFn, $fn)`（同上）
- README API Reference の `match()` シグネチャを実装に一致させる
- README Basic Usage の `match(ok: ..., err: ...)` の例はこの変更で**そのまま動くようになります**

## BC への影響

名前付き引数でこれらを渡している呼び出し元は引数名の更新が必要です（BREAKING CHANGE として明記）。位置引数の呼び出しには影響ありません。

## TDD

1. 名前付き引数の使用をピン留めするテスト 4 件を先に追加し、RED（`Unknown named parameter $ok`）を確認してコミット
2. 改名を実装して GREEN（73 tests / PHPStan max / cs-fixer すべてパス）

## 関連

- #90（README 修正）とこの PR の両方がマージされる場合、Basic Usage の match 例は名前付き引数版（この PR で有効になる形）に戻して問題ありません。

https://claude.ai/code/session_017XTM7pxbWPVNLV639i5WgK