### PR TITLE
fix: stop composer test from masking failures and skipping tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit --do-not-fail-on-warning || exit 0",
+        "test": "phpunit",
         "phpstan": "phpstan analyse",
         "cs-fix": "php-cs-fixer fix --verbose",
         "cs-check": "php-cs-fixer fix --verbose --dry-run",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -33,10 +33,4 @@
             <directory suffix=".php">src</directory>
         </include>
     </source>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="php://stdout"/>
-        </report>
-    </coverage>
 </phpunit>


### PR DESCRIPTION
## 概要

コードレビューで指摘した「`composer test` がテスト失敗を握りつぶす」問題の修正です。調査の結果、実際はさらに悪い状態でした。

## 問題

1. `"test": "phpunit --do-not-fail-on-warning || exit 0"` の `|| exit 0` により、テストが失敗しても `composer test`（および `composer check`）は成功扱いになる
2. さらに、phpunit.xml の `<coverage>` レポート設定により、カバレッジドライバ（pcov/xdebug）が無い環境では **PHPUnit 12 がテストを 1 件も実行せず終了する**ことを確認しました:

```
1) No code coverage driver available
No tests executed!
```

つまりドライバ無しのローカル環境では「テスト 0 件実行 + exit 0」で、`composer check` が何も検証していませんでした。

## 修正

- `|| exit 0` と `--do-not-fail-on-warning` を削除（警告での失敗は phpunit.xml の `failOnWarning="false"` で既に制御されており冗長）
- phpunit.xml の `<coverage>` レポートブロックを削除。CI は pcov をロードした上で `--coverage-clover` 等を CLI フラグで渡しているため、この XML 設定は CI では未使用でした

## 検証（PHP 8.4.7、カバレッジドライバなし）

- 修正後 `phpunit`: 69 tests / 111 assertions パス、exit 0
- 故意に失敗するテストを置いた場合: exit 1（失敗が伝播することを確認後、削除）
- `composer validate --strict`: パス

https://claude.ai/code/session_017XTM7pxbWPVNLV639i5WgK