### PR TITLE
feat: support PHP 8.3

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -28,9 +28,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
         restore-keys: |
-          ${{ runner.os }}-php-
+          ${{ runner.os }}-php-${{ matrix.php-version }}-
     
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        php-version: ['8.4', '8.5']
+        php-version: ['8.3', '8.4', '8.5']
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -32,9 +32,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
         restore-keys: |
-          ${{ runner.os }}-php-
+          ${{ runner.os }}-php-${{ matrix.php-version }}-
     
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        php-version: ['8.4', '8.5']
+        php-version: ['8.3', '8.4', '8.5']
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.4', '8.5']
+        php: ['8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,10 +11,10 @@ $finder = PhpCsFixer\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return new PhpCsFixer\Config()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
-        '@PHP84Migration' => true,
+        '@PHP83Migration' => true,
         'array_syntax' => ['syntax' => 'short'],
         'blank_line_after_namespace' => true,
         'blank_line_after_opening_tag' => true,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require valbeat/result
 
 ## Requirements
 
-- PHP 8.4 or higher (tested on PHP 8.4 and 8.5)
+- PHP 8.3 or higher (tested on PHP 8.3, 8.4 and 8.5)
 - Composer
 
 ## Basic Usage

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^8.4"
+        "php": "^8.3"
     },
     "require-dev": {
         "phpstan/phpstan": "2.2.5",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
     checkBenevolentUnionTypes: true
     checkUninitializedProperties: true
     
-    # Supported PHP versions (8.4 - 8.5)
+    # Supported PHP versions (8.3 - 8.5)
     phpVersion:
-        min: 80400
+        min: 80300
         max: 80500


### PR DESCRIPTION
## 概要

コードレビューで指摘した「`php: ^8.4` は必要以上に厳しい」への対応です。

このライブラリが使う最新の言語機能は readonly class（8.2）と `#[Override]`（8.3）で、8.4 固有の機能は使用していません。要求を `^8.3` に緩めることで採用可能なプロジェクトの裾野が広がります。

## 変更内容

- composer.json: `php: ^8.4` → `^8.3`（dev 依存の phpunit 12.5 / php-cs-fixer 3.95 / phpstan は 8.3 対応済み）
- phpstan.neon: `phpVersion.min` を 80300 に
- CI 3 ワークフロー（test / phpstan / code-style）のマトリクスに 8.3 を追加
- README の Requirements を更新

## 検証

- PHPStan（level max, `phpVersion: min 80300`）: エラーなし — 8.4 専用のシンボル・構文が使われていないことを解析レベルで確認
- PHP 8.4 でのテスト: 69 tests パス（回 帰なし）
- **実 PHP 8.3 でのテスト実行はこの PR で追加した CI マトリクスが担います**（ローカルに 8.3 実行環境がないため）。マージ前に CI の 8.3 ジョブが green であることを確認してください。

https://claude.ai/code/session_017XTM7pxbWPVNLV639i5WgK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 対応する最小 PHP バージョンを 8.3 以上に拡大し、動作確認済みの範囲を 8.3 / 8.4 / 8.5 に更新しました。
* **Chores**
  * CI の各種チェックを PHP 8.3, 8.4, 8.5 で実行するように調整しました。
  * キャッシュ設定を PHP バージョンごとに分け、ビルドの再利用性を改善しました。
* **Documentation**
  * 必要環境の記載を最新の対応バージョンに合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->