### PR TITLE
feat: add expect() and expectErr() throwing UnwrapException

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ All Result types (both Ok and Err) implement these methods:
 #### Value Extraction
 - `unwrap(): mixed` - Returns the success value or throws LogicException
 - `unwrapErr(): mixed` - Returns the error value or throws LogicException
+- `expect(string $message): mixed` - Returns the success value or throws LogicException with the given message
+- `expectErr(string $message): mixed` - Returns the error value or throws LogicException with the given message
 - `unwrapOr(mixed $default): mixed` - Returns the success value or a default
 - `unwrapOrElse(callable $fn): mixed` - Returns the success value or computes it from the error
 

--- a/src/Err.php
+++ b/src/Err.php
@@ -65,7 +65,7 @@ final readonly class Err implements Result
     #[Override]
     public function expect(string $message): never
     {
-        throw new \LogicException($message);
+        throw UnwrapException::withMessage($message, $this->value);
     }
 
     /**

--- a/src/Err.php
+++ b/src/Err.php
@@ -62,6 +62,21 @@ final readonly class Err implements Result
         return $this->value;
     }
 
+    #[Override]
+    public function expect(string $message): never
+    {
+        throw new \LogicException($message);
+    }
+
+    /**
+     * @return E
+     */
+    #[Override]
+    public function expectErr(string $message): mixed
+    {
+        return $this->value;
+    }
+
     /**
      * @template U
      * @param U $default

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -63,6 +63,21 @@ final readonly class Ok implements Result
     }
 
     /**
+     * @return T
+     */
+    #[Override]
+    public function expect(string $message): mixed
+    {
+        return $this->value;
+    }
+
+    #[Override]
+    public function expectErr(string $message): never
+    {
+        throw new \LogicException($message);
+    }
+
+    /**
      * @template U
      * @param U $default
      * @return T

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -74,7 +74,7 @@ final readonly class Ok implements Result
     #[Override]
     public function expectErr(string $message): never
     {
-        throw new \LogicException($message);
+        throw UnwrapException::withMessage($message, $this->value);
     }
 
     /**

--- a/src/Result.php
+++ b/src/Result.php
@@ -77,18 +77,22 @@ interface Result
     /**
      * 成功値を返します。失敗の場合は指定したメッセージで例外を投げます.
      *
-     * @param string $message 失敗時の例外メッセージ
+     * @param string $message 失敗時の例外メッセージ（エラー値の要約が付加されます）
      *
      * @return ($this is Ok<mixed> ? T : never)
+     *
+     * @throws UnwrapException $this が Err の場合
      */
     public function expect(string $message): mixed;
 
     /**
      * エラー値を返します。成功の場合は指定したメッセージで例外を投げます.
      *
-     * @param string $message 成功時の例外メッセージ
+     * @param string $message 成功時の例外メッセージ（成功値の要約が付加されます）
      *
      * @return ($this is Err<mixed> ? E : never)
+     *
+     * @throws UnwrapException $this が Ok の場合
      */
     public function expectErr(string $message): mixed;
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -71,6 +71,24 @@ interface Result
     public function unwrapErr(): mixed;
 
     /**
+     * 成功値を返します。失敗の場合は指定したメッセージで例外を投げます.
+     *
+     * @param string $message 失敗時の例外メッセージ
+     *
+     * @return ($this is Ok<mixed> ? T : never)
+     */
+    public function expect(string $message): mixed;
+
+    /**
+     * エラー値を返します。成功の場合は指定したメッセージで例外を投げます.
+     *
+     * @param string $message 成功時の例外メッセージ
+     *
+     * @return ($this is Err<mixed> ? E : never)
+     */
+    public function expectErr(string $message): mixed;
+
+    /**
      * 成功値またはデフォルト値を返します.
      *
      * @template U

--- a/src/UnwrapException.php
+++ b/src/UnwrapException.php
@@ -36,6 +36,14 @@ final class UnwrapException extends \LogicException
     }
 
     /**
+     * expect() / expectErr() 用に、呼び出し側のメッセージと値の要約から例外を生成します.
+     */
+    public static function withMessage(string $message, mixed $value): self
+    {
+        return new self(\sprintf('%s: %s', $message, self::describe($value)));
+    }
+
+    /**
      * 例外メッセージ用に値の要約を生成します.
      *
      * 要約は単一行に正規化し、MAX_SUMMARY_LENGTH を超える部分は切り詰めます.

--- a/tests/ErrTest.php
+++ b/tests/ErrTest.php
@@ -163,6 +163,15 @@ class ErrTest extends TestCase
     }
 
     #[Test]
+    public function expect_throwsUnwrapException_withErrorValueInMessage(): void
+    {
+        $err = new Err(new \RuntimeException('boom'));
+        $this->expectException(UnwrapException::class);
+        $this->expectExceptionMessage('config file should be readable: RuntimeException: boom');
+        $err->expect('config file should be readable');
+    }
+
+    #[Test]
     public function unwrapErr_returns_error_value(): void
     {
         $err = new Err('error message');

--- a/tests/ErrTest.php
+++ b/tests/ErrTest.php
@@ -59,6 +59,22 @@ class ErrTest extends TestCase
     }
 
     #[Test]
+    public function expect_throws_withGivenMessage(): void
+    {
+        $err = new Err('error');
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('config file should be readable');
+        $err->expect('config file should be readable');
+    }
+
+    #[Test]
+    public function expectErr_returns_error_value(): void
+    {
+        $err = new Err('error');
+        $this->assertSame('error', $err->expectErr('should have an error'));
+    }
+
+    #[Test]
     public function unwrapErr_returns_error_value(): void
     {
         $err = new Err('error message');

--- a/tests/OkTest.php
+++ b/tests/OkTest.php
@@ -90,6 +90,22 @@ class OkTest extends TestCase
     }
 
     #[Test]
+    public function expect_returns_value(): void
+    {
+        $ok = new Ok(42);
+        $this->assertSame(42, $ok->expect('should have a value'));
+    }
+
+    #[Test]
+    public function expectErr_throws_withGivenMessage(): void
+    {
+        $ok = new Ok(42);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('should have an error');
+        $ok->expectErr('should have an error');
+    }
+
+    #[Test]
     public function unwrapOr_returns_value(): void
     {
         $ok = new Ok(42);

--- a/tests/OkTest.php
+++ b/tests/OkTest.php
@@ -131,6 +131,15 @@ class OkTest extends TestCase
     }
 
     #[Test]
+    public function expectErr_throwsUnwrapException_withValueInMessage(): void
+    {
+        $ok = new Ok(42);
+        $this->expectException(UnwrapException::class);
+        $this->expectExceptionMessage('should have an error: 42');
+        $ok->expectErr('should have an error');
+    }
+
+    #[Test]
     public function unwrapOr_returns_value(): void
     {
         $ok = new Ok(42);

--- a/tests/Types/result.php
+++ b/tests/Types/result.php
@@ -255,6 +255,17 @@ function testUnwrapOnGenericReceiver(Result $result): void
 }
 
 /**
+ * expect / expectErr も unwrap / unwrapErr と同じ条件付き戻り値型が解決される.
+ *
+ * @param Result<int, RuntimeException> $result
+ */
+function testExpectOnGenericReceiver(Result $result): void
+{
+    assertType('int', $result->expect('should have a value'));
+    assertType('RuntimeException', $result->expectErr('should have an error'));
+}
+
+/**
  * 具象レシーバでの unwrapOr / unwrapOrElse: 実行時に起こり得ない側の型を混ぜない.
  *
  * @param Ok<int> $ok


### PR DESCRIPTION
## 概要

#95 の後継 PR です（#94 のブランチ削除に伴い #95 が自動クローズされ、クローズ済み PR は base 変更・再オープンともに不可のため作り直し）。内容・ブランチ・コミット履歴は #95 と同一で、#94 が main に入ったため差分は expect 分のみです。

Rust の `Result::expect` / `expect_err` 相当を追加します。レビュー指摘を反映済みで、`unwrap()` 系と同じ `UnwrapException`（呼び出し側メッセージ + 値の要約）を投げ、`catch (UnwrapException)` が unwrap 系 4 メソッドすべてをカバーします。

```php
$config = loadConfig()->expect('config.json should exist and be valid');
// 失敗時: UnwrapException('config.json should exist and be valid: RuntimeException: ...')
```

## 変更内容

- `Result::expect(string $message)` / `Result::expectErr(string $message)`（インターフェース + Ok / Err 実装、`@throws UnwrapException` 付き）
- `UnwrapException::withMessage(string, mixed)` ファクトリを追加
- 条件付き戻り値型は `unwrap()` 系と同一（型テストでピン留め）
- README の Value Extraction に追記

## TDD

テスト先行（RED 確認 → コミット → 実装）。85 tests / PHPStan max / cs-fixer すべてローカルでパス済み。

https://claude.ai/code/session_017XTM7pxbWPVNLV639i5WgK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Result` に、成功時/失敗時の値を指定メッセージ付きで確認できる `expect()` / `expectErr()` が追加されました。
  * 失敗時の例外メッセージに、元の値の要約が含まれるようになりました。
  * `Ok` / `Err` で期待値の取得と例外発生の挙動が統一されました。
* **Tests**
  * 新しい期待値取得メソッドの返却値、例外メッセージ、型推論を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->