### PR TITLE
test: remove 22 redundant test cases

### DIFF
--- a/tests/ErrTest.php
+++ b/tests/ErrTest.php
@@ -60,15 +60,6 @@ class ErrTest extends TestCase
     }
 
     #[Test]
-    public function expect_throws_withGivenMessage(): void
-    {
-        $err = new Err('error');
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('config file should be readable');
-        $err->expect('config file should be readable');
-    }
-
-    #[Test]
     public function expectErr_returns_error_value(): void
     {
         $err = new Err('error');
@@ -100,18 +91,6 @@ class ErrTest extends TestCase
         $this->expectException(UnwrapException::class);
         $this->expectExceptionMessage('called Result::unwrap() on an Err value: array');
         $err->unwrap();
-    }
-
-    #[Test]
-    public function unwrapException_remainsCatchableAsLogicException(): void
-    {
-        $err = new Err('error');
-
-        try {
-            $err->unwrap();
-        } catch (\LogicException $e) {
-            $this->assertInstanceOf(UnwrapException::class, $e);
-        }
     }
 
     #[Test]
@@ -179,41 +158,10 @@ class ErrTest extends TestCase
     }
 
     #[Test]
-    public function unwrapErr_withIntValue_returns_int(): void
-    {
-        $err = new Err(404);
-        $this->assertSame(404, $err->unwrapErr());
-    }
-
-    #[Test]
-    public function unwrapErr_withArrayValue_returns_array(): void
-    {
-        $error = ['code' => 500, 'message' => 'Internal Server Error'];
-        $err = new Err($error);
-        $this->assertSame($error, $err->unwrapErr());
-    }
-
-    #[Test]
-    public function unwrapErr_withObjectValue_returns_object(): void
-    {
-        $error = new \Exception('Test exception');
-        $err = new Err($error);
-        $this->assertSame($error, $err->unwrapErr());
-    }
-
-    #[Test]
     public function unwrapOr_returns_default(): void
     {
         $err = new Err('error');
         $this->assertSame(42, $err->unwrapOr(42));
-    }
-
-    #[Test]
-    public function unwrapOr_withDifferentTypes_returns_default(): void
-    {
-        $err = new Err('error');
-        $this->assertSame('default', $err->unwrapOr('default'));
-        $this->assertSame(['default'], $err->unwrapOr(['default']));
     }
 
     #[Test]
@@ -248,15 +196,6 @@ class ErrTest extends TestCase
         $mapped = $err->mapErr(fn ($e) => strtoupper($e));
         $this->assertInstanceOf(Err::class, $mapped);
         $this->assertSame('ERROR', $mapped->unwrapErr());
-    }
-
-    #[Test]
-    public function mapErr_withTypeChange_transforms_type(): void
-    {
-        $err = new Err(404);
-        $mapped = $err->mapErr(fn ($code) => "Error code: $code");
-        $this->assertInstanceOf(Err::class, $mapped);
-        $this->assertSame('Error code: 404', $mapped->unwrapErr());
     }
 
     #[Test]
@@ -329,16 +268,6 @@ class ErrTest extends TestCase
     }
 
     #[Test]
-    public function andThen_withDifferentErrorType_keeps_original_error(): void
-    {
-        $err = new Err(self::asString('validation failed'));
-        $result = $err->andThen(fn ($x) => new Err(new \DomainException('unreachable')));
-
-        $this->assertSame($err, $result);
-        $this->assertSame('validation failed', $result->unwrapErr());
-    }
-
-    #[Test]
     public function or_withAnotherErr_returns_second_err(): void
     {
         $err1 = new Err('error1');
@@ -379,17 +308,6 @@ class ErrTest extends TestCase
     }
 
     #[Test]
-    public function match_withDifferentReturnTypes_returns_err_branch(): void
-    {
-        $err = new Err(404);
-        $result = $err->match(
-            fn ($value) => ['status' => 'ok', 'data' => $value],
-            fn ($error) => ['status' => 'error', 'code' => $error],
-        );
-        $this->assertSame(['status' => 'error', 'code' => 404], $result);
-    }
-
-    #[Test]
     public function match_supportsNamedArguments(): void
     {
         $err = new Err('error');
@@ -426,22 +344,6 @@ class ErrTest extends TestCase
     }
 
     #[Test]
-    public function err_withZeroValue_handles_zero(): void
-    {
-        $err = new Err(0);
-        $this->assertSame(0, $err->unwrapErr());
-        $this->assertTrue($err->isErr());
-    }
-
-    #[Test]
-    public function err_withEmptyString_handles_empty_string(): void
-    {
-        $err = new Err('');
-        $this->assertSame('', $err->unwrapErr());
-        $this->assertTrue($err->isErr());
-    }
-
-    #[Test]
     public function chainingOperations_applies_transformations(): void
     {
         $err = new Err('initial error');
@@ -452,19 +354,6 @@ class ErrTest extends TestCase
 
         $this->assertInstanceOf(Err::class, $result);
         $this->assertSame('Final: [INITIAL ERROR]', $result->unwrapErr());
-    }
-
-    #[Test]
-    public function exceptionAsErrorValue_handles_exception(): void
-    {
-        $exception = new \RuntimeException('Something went wrong');
-        $err = new Err($exception);
-
-        $this->assertTrue($err->isErr());
-        $this->assertSame($exception, $err->unwrapErr());
-
-        $handled = $err->mapErr(fn ($e) => $e->getMessage());
-        $this->assertSame('Something went wrong', $handled->unwrapErr());
     }
 
     /**

--- a/tests/OkTest.php
+++ b/tests/OkTest.php
@@ -58,30 +58,6 @@ class OkTest extends TestCase
     }
 
     #[Test]
-    public function unwrap_withStringValue_returns_string(): void
-    {
-        $ok = new Ok('hello');
-        $this->assertSame('hello', $ok->unwrap());
-    }
-
-    #[Test]
-    public function unwrap_withArrayValue_returns_array(): void
-    {
-        $value = ['foo' => 'bar'];
-        $ok = new Ok($value);
-        $this->assertSame($value, $ok->unwrap());
-    }
-
-    #[Test]
-    public function unwrap_withObjectValue_returns_object(): void
-    {
-        $value = new \stdClass();
-        $value->foo = 'bar';
-        $ok = new Ok($value);
-        $this->assertSame($value, $ok->unwrap());
-    }
-
-    #[Test]
     public function unwrapErr_throws_exception(): void
     {
         $ok = new Ok(42);
@@ -95,15 +71,6 @@ class OkTest extends TestCase
     {
         $ok = new Ok(42);
         $this->assertSame(42, $ok->expect('should have a value'));
-    }
-
-    #[Test]
-    public function expectErr_throws_withGivenMessage(): void
-    {
-        $ok = new Ok(42);
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('should have an error');
-        $ok->expectErr('should have an error');
     }
 
     #[Test]
@@ -161,15 +128,6 @@ class OkTest extends TestCase
         $mapped = $ok->map(fn ($x) => $x * 2);
         $this->assertInstanceOf(Ok::class, $mapped);
         $this->assertSame(20, $mapped->unwrap());
-    }
-
-    #[Test]
-    public function map_withTypeChange_transforms_type(): void
-    {
-        $ok = new Ok(42);
-        $mapped = $ok->map(fn ($x) => "Value is: $x");
-        $this->assertInstanceOf(Ok::class, $mapped);
-        $this->assertSame('Value is: 42', $mapped->unwrap());
     }
 
     #[Test]
@@ -241,32 +199,6 @@ class OkTest extends TestCase
     }
 
     #[Test]
-    public function andThen_withDifferentErrorType_chains_results(): void
-    {
-        $ok = new Ok(self::asInt(10));
-        $result = $ok->andThen(
-            fn ($x) => $x > 5 ? new Ok("value: $x") : new Err(new \DomainException('too small')),
-        );
-
-        $this->assertInstanceOf(Ok::class, $result);
-        $this->assertSame('value: 10', $result->unwrap());
-    }
-
-    #[Test]
-    public function andThen_withDifferentErrorType_returns_new_err(): void
-    {
-        $ok = new Ok(self::asInt(3));
-        $result = $ok->andThen(
-            fn ($x) => $x > 5 ? new Ok("value: $x") : new Err(new \DomainException('too small')),
-        );
-
-        $this->assertInstanceOf(Err::class, $result);
-        $error = $result->unwrapErr();
-        $this->assertInstanceOf(\DomainException::class, $error);
-        $this->assertSame('too small', $error->getMessage());
-    }
-
-    #[Test]
     public function or_returns_self(): void
     {
         $ok1 = new Ok(42);
@@ -307,17 +239,6 @@ class OkTest extends TestCase
     }
 
     #[Test]
-    public function match_withDifferentReturnTypes_returns_ok_branch(): void
-    {
-        $ok = new Ok('hello');
-        $result = $ok->match(
-            fn ($value) => \strlen($value),
-            fn ($error) => -1,
-        );
-        $this->assertSame(5, $result);
-    }
-
-    #[Test]
     public function match_supportsNamedArguments(): void
     {
         $ok = new Ok(42);
@@ -350,22 +271,6 @@ class OkTest extends TestCase
     {
         $ok = new Ok(false);
         $this->assertFalse($ok->unwrap());
-        $this->assertTrue($ok->isOk());
-    }
-
-    #[Test]
-    public function ok_withZeroValue_handles_zero(): void
-    {
-        $ok = new Ok(0);
-        $this->assertSame(0, $ok->unwrap());
-        $this->assertTrue($ok->isOk());
-    }
-
-    #[Test]
-    public function ok_withEmptyString_handles_empty_string(): void
-    {
-        $ok = new Ok('');
-        $this->assertSame('', $ok->unwrap());
         $this->assertTrue($ok->isOk());
     }
 


### PR DESCRIPTION
## 概要

テストスイートのレビューで特定した、**固有の失敗モードを持たない冗長テスト 22 件**を削除します（99 → 77 tests、削除のみ 206 行）。実行時間ではなく、仕様変更時に同じ原因で複数テストが一斉に落ちるノイズと保守コストの削減が目的です。

## 削除の内訳

| グループ | 件数 | 理由 |
|---|---|---|
| 値の型バリエーション（string/array/object/int を unwrap 系に通すだけ） | 8 | アクセサは分岐のない 1 文の return で、値の型でコードパスが変わらない。各メソッドの基本形テストは残置 |
| falsy 値ピンの過剰分（`0` / `''`） | 4 | null（isset 系）と false（truthiness 系）で失敗モードは尽きており、両方とも各クラスに残置 |
| ランタイムの「型が変わる」系（map/mapErr/match/andThen） | 7 | PHP は動的型付けで基本形と同一パス。型合成の関心事は tests/Types/result.php の assertType が正しいレイヤーでピン留め済み |
| 進化の名残（強いテストに厳密包含される弱いアサーション） | 3 | `expect_throws_withGivenMessage` 等は `*_throwsUnwrapException` 変種に包含。`UnwrapException extends LogicException` の事実は残置テスト（`unwrap_throws_exception` が `\LogicException` を期待してパス）でピン留め継続 |

## 残しているもの（一見冗長だが意図あり）

- `unwrap_throws_exception` のメッセージプレフィックス検証 — 前方一致に依存する利用者への BC ピン
- `match_supportsNamedArguments` の Ok/Err 両方 — PHP はインターフェースとの**引数名**一致を強制しないため、クラスごとに独立してドリフトし得る
- `describe()` のエッジテスト群 — 各々が別分岐をピン
- null / false の falsy ピン — リファクタリング保険として残置

## 検証

- 削除された各テストは同一コードパスを検証する残置テストと対になっているため、**src/ の行カバレッジは不変**（codecov project/patch チェックで CI 上も確認可能）
- 77 tests / 121 assertions パス、PHPStan level max エラーなし（未使用ヘルパー警告なし）、cs-fixer クリーン

https://claude.ai/code/session_017XTM7pxbWPVNLV639i5WgK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テスト構成を見直し、一部のケースを整理しました。
  * `unwrap`、`map`、`andThen`、`match` などの検証対象を簡素化し、`unwrapOr` の確認を追加しました。
  * 0 や空文字などの境界値に関するテストの一部を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->