### PR TITLE
fix: keep truncated UnwrapException message valid UTF-8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": "^8.3"
+        "php": "^8.3",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpstan/phpstan": "2.2.5",

--- a/src/UnwrapException.php
+++ b/src/UnwrapException.php
@@ -61,7 +61,9 @@ final class UnwrapException extends \LogicException
 
         $summary = str_replace(["\r\n", "\r", "\n"], '\n', $summary);
         if (\strlen($summary) > self::MAX_SUMMARY_LENGTH) {
-            return substr($summary, 0, self::MAX_SUMMARY_LENGTH) . '... (truncated)';
+            // バイト上限を守りつつ文字境界で切るため mb_strcut を使う（substr だと
+            // マルチバイト文字の途中で切れて不正な UTF-8 になり json_encode が失敗する）.
+            return mb_strcut($summary, 0, self::MAX_SUMMARY_LENGTH, 'UTF-8') . '... (truncated)';
         }
 
         return $summary;

--- a/tests/ErrTest.php
+++ b/tests/ErrTest.php
@@ -142,6 +142,28 @@ class ErrTest extends TestCase
     }
 
     #[Test]
+    public function unwrap_withLongMultibyteError_keepsValidUtf8Message(): void
+    {
+        // 各文字 3 バイトなので、120 バイトの切り詰め境界が文字の途中に落ちる
+        $err = new Err(str_repeat('あ', 200));
+
+        try {
+            $err->unwrap();
+        } catch (UnwrapException $e) {
+            $message = $e->getMessage();
+            $this->assertTrue(
+                mb_check_encoding($message, 'UTF-8'),
+                'truncated message must remain valid UTF-8',
+            );
+            $this->assertNotFalse(
+                json_encode(['message' => $message]),
+                'message must be json_encode-able (no malformed UTF-8)',
+            );
+            $this->assertStringContainsString('(truncated)', $message);
+        }
+    }
+
+    #[Test]
     public function expect_throwsUnwrapException_withErrorValueInMessage(): void
     {
         $err = new Err(new \RuntimeException('boom'));


### PR DESCRIPTION
## 概要

コードレビュー（Opus 独立レビュー含む）で見つかった実バグの修正です。`UnwrapException::describe()` の値要約の切り詰めがバイト単位の `substr()` を使っているため、マルチバイト文字を含む長い値では **120 バイト目で文字の途中を切って不正な UTF-8 を生成**し、例外メッセージの `json_encode()` が失敗します。

## 再現（修正前）

```php
$err = new Err(str_repeat('あ', 200)); // 各文字 3 バイト
$err->unwrap();
// → UnwrapException のメッセージが不正な UTF-8 を含む
// → json_encode(['message' => $e->getMessage()]) === false
//    (json_last_error: "Malformed UTF-8 characters")
```

エラーハンドリング経路（＝すでに何か失敗している最中）で、ログ基盤が例外メッセージを JSON 化しようとすると二次障害になります。ドックブロックがすべて日本語のプロジェクトであり、エラー値に日本語文字列が載るのは現実的なシナリオです。

## 修正

- `src/UnwrapException.php`: 切り詰めを `substr()` → **`mb_strcut($summary, 0, 120, 'UTF-8')`** に変更。`mb_strcut` はバイト上限を超えない範囲で文字境界を保って切ります（バイト予算はそのまま維持）。
- `composer.json`: これにより生じる `ext-mbstring` 依存を `require` に宣言。

## 検証

- 追加テスト `unwrap_withLongMultibyteError_keepsValidUtf8Message`（`tests/ErrTest.php`）で、切り詰め後のメッセージが `mb_check_encoding(..., 'UTF-8')` を通り `json_encode` が成功することをピン留め
- 修正後の実測: `bytes=176 valid_utf8=yes json=ok`
- 78 tests / 124 assertions パス、PHPStan level max エラーなし、cs-fixer クリーン

## TDD

1. マルチバイト切り詰めの回帰テストを先に追加し RED（`truncated message must remain valid UTF-8` failure）を確認してコミット
2. `mb_strcut` で実装して GREEN

https://claude.ai/code/session_017XTM7pxbWPVNLV639i5WgK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 長いエラーメッセージの切り詰め時に、マルチバイト文字が崩れにくくなりました。
  * 文字化けや不正な UTF-8 が混ざる可能性を減らし、より安全にエラーメッセージを扱えるようになりました。

* **Chores**
  * 必要な PHP 拡張の要件が明示されました。

* **Tests**
  * 長い多バイト文字を含むエラー表示が正しく切り詰められることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->